### PR TITLE
Add Superstructure states and transitions

### DIFF
--- a/src/com/spartronics4915/frc2018/subsystems/Harvester.java
+++ b/src/com/spartronics4915/frc2018/subsystems/Harvester.java
@@ -307,6 +307,46 @@ public class Harvester extends Subsystem
         dashboardPutWantedState(mWantedState.toString());
     }
     
+    public boolean atTarget()
+    {
+        boolean t = false;
+        switch (mSystemState)
+        {
+            case CLOSING:
+                if (mWantedState == WantedState.CLOSE)
+                    t = true;
+                break;
+            case OPENING:
+                if (mWantedState == WantedState.OPEN)
+                    t = true;
+                break;
+            case HARVESTING:
+                if (mWantedState == WantedState.HARVEST)
+                    t = true;
+                break;
+            case EJECTING:
+                if (mWantedState == WantedState.EJECT)
+                    t = true;
+                break;
+            case HUGGING:
+                if (mWantedState == WantedState.HUG)
+                    t = true;
+                break;
+            case PREHARVESTING:
+                if (mWantedState == WantedState.PREHARVEST)
+                    t = true;
+                break;
+            case DISABLING:
+                if (mWantedState == WantedState.DISABLE)
+                    t = true;
+                break;
+            default:
+                t = false;
+                break;
+        }
+        return t;
+    }
+    
     private boolean isCubeHeld()
     {
         return mCubeHeldSensor.isTargetInDistanceRange(kCubeMinDistanceInches, kCubeMaxDistanceInches);

--- a/src/com/spartronics4915/frc2018/subsystems/ScissorLift.java
+++ b/src/com/spartronics4915/frc2018/subsystems/ScissorLift.java
@@ -156,6 +156,35 @@ public class ScissorLift extends Subsystem
         mWantedState = wantedState;
         dashboardPutWantedState(wantedState.toString());
     }
+    
+    public synchronized boolean atTarget()
+    {
+        boolean matches = false;
+        switch (mSystemState)
+        {
+            case OFF:
+                matches = (mWantedState == WantedState.OFF);
+                break;
+            case RAISING:
+                matches = false;
+                break;
+            case LOWERING:
+                matches = false;
+                break;
+            case HOLDING:
+                matches  = (mWantedState == WantedState.RETRACTED || mWantedState == WantedState.OFF || mWantedState == WantedState.SWITCH || mWantedState == WantedState.SCALE);
+            case BRAKING:
+                matches = false;
+                break;
+            case UNBRAKING:
+                matches = false;
+                break;
+            default:
+                matches = false;
+                break;
+        }
+        return matches;
+    }
 
     @Override
     public void outputToSmartDashboard()
@@ -193,7 +222,7 @@ public class ScissorLift extends Subsystem
     {
         enabledLooper.register(mLoop);
     }
-
+    
     // based on the combination of wanted state, current state and the current potentiometer value,
     // transfer the current system state to another state.
     /*

--- a/src/com/spartronics4915/frc2018/subsystems/Superstructure.java
+++ b/src/com/spartronics4915/frc2018/subsystems/Superstructure.java
@@ -124,7 +124,12 @@ public class Superstructure extends Subsystem
                         if (mStateChanged)
                             mGrabber.setWantedState(ArticulatedGrabber.WantedState.TRANSPORT);
                         else if (mWantedState == WantedState.RETRACT_FROM_DUNK)
-                            
+                        {
+                            if (mLifter.atTarget())
+                                newState = SystemState.RETRACTING_SCISSOR;
+                        }
+                        else
+                            newState = defaultStateTransfer();
                         break;
                     case RETRACTING_SCISSOR:
                         if (mStateChanged)

--- a/src/com/spartronics4915/frc2018/subsystems/Superstructure.java
+++ b/src/com/spartronics4915/frc2018/subsystems/Superstructure.java
@@ -120,9 +120,12 @@ public class Superstructure extends Subsystem
                         if (mStateChanged)
                             mGrabber.setWantedState(ArticulatedGrabber.WantedState.TRANSPORT);
                         break;
-//                    case RETRACTING_SCISSOR:
-//                        newState = handleDunkRetract(mStateChanged);
-//                        break;
+                    case RETRACTING_SCISSOR:
+                        if (mStateChanged)
+                            mLifter.setWantedState(ScissorLift.WantedState.RETRACTED);
+                        else if (mLifter.atTarget())
+                            newState = SystemState.PREPARING_ARTICULATED_GRABBER;
+                        break;
 //                    case PREPARING_ARTICULATED_GRABBER:  // Transfer cube from harvester to scissor
 //                        newState = handleTransferCube(mStateChanged);
 //                        break;


### PR DESCRIPTION
* Also added `atTarget` methods to subsystems that needed it. This allows `Superstructure` to decide on when to transition to the next state in the chain.
* Fixed variable naming conventions and did other cosmetic cleanup on `ArticulatedGrabber`.